### PR TITLE
Improve Entity Name Validation

### DIFF
--- a/lib/rplate/cli.rb
+++ b/lib/rplate/cli.rb
@@ -18,7 +18,6 @@ module RPlate
     end
 
     def self.exit_on_failure?
-      puts 'failure'
       true
     end
   end

--- a/lib/rplate/commands/generate/validate_params.rb
+++ b/lib/rplate/commands/generate/validate_params.rb
@@ -8,7 +8,9 @@ module RPlate
       class ValidateParams
         include Hanami::Validations
 
-        ALLOWED_NAME_REGEX = /([a-zA-Z]+)(:{2}|_)?/.freeze
+        CONSTANT_REGEX = /[A-Za-z]\w*/.freeze
+        SPLIT_REGEX = %r{:{1,2}|/}.freeze
+        ALLOWED_NAME_REGEX = /\A#{CONSTANT_REGEX}(#{SPLIT_REGEX}#{CONSTANT_REGEX})?\z/.freeze
         ALLOWED_TYPES = %w[class module].freeze
         ALLOWED_METHODS_REGEX = /(self.)?([a-z]+_?)/.freeze
 

--- a/spec/lib/rplate/commands/generate/validate_params_spec.rb
+++ b/spec/lib/rplate/commands/generate/validate_params_spec.rb
@@ -36,7 +36,25 @@ RSpec.describe RPlate::Commands::Generate::ValidateParams do
       end
     end
 
-    context 'when name is downcase with namespace' do
+    context 'when name is downcase with spaces' do
+      let(:class_name) { 'my_module my_class' }
+
+      it 'is not success' do
+        expect(subject).not_to be_success
+        expect(subject.messages).to include(name: ['is in invalid format'])
+      end
+    end
+
+    context 'when name is downcase with spaces' do
+      let(:class_name) { 'MyModule MyClass' }
+
+      it 'is not success' do
+        expect(subject).not_to be_success
+        expect(subject.messages).to include(name: ['is in invalid format'])
+      end
+    end
+
+    context 'when name is downcase and splitted by `:`' do
       let(:class_name) { 'my_module/my_class' }
 
       it 'is success' do
@@ -54,6 +72,24 @@ RSpec.describe RPlate::Commands::Generate::ValidateParams do
 
     context 'when name is blank' do
       let(:class_name) { '' }
+
+      it 'is not success' do
+        expect(subject).not_to be_success
+        expect(subject.messages).to include(name: ['is in invalid format'])
+      end
+    end
+
+    context 'when name is start with number and underscore' do
+      let(:class_name) { '2class' }
+
+      it 'is not success' do
+        expect(subject).not_to be_success
+        expect(subject.messages).to include(name: ['is in invalid format'])
+      end
+    end
+
+    context 'when name is start with number' do
+      let(:class_name) { '2Class' }
 
       it 'is not success' do
         expect(subject).not_to be_success


### PR DESCRIPTION
Do not allow entity names:
- separated by white spaces
- starting with number


###### Note

Referes to #1 